### PR TITLE
Some documentations correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ Profiling for your machine can be done by running
 python profile_torchkbnufft.py
 ```
 
+You will need to install some other packages to run this profiling
+
+```
+pip install scikit-image Pillow
+```
+
 ## Other Packages
 
 For users interested in NUFFT implementations for other computing platforms, the following is a partial list of other projects:

--- a/torchkbnufft/nufft/utils.py
+++ b/torchkbnufft/nufft/utils.py
@@ -109,9 +109,8 @@ def build_table(numpoints, table_oversamp, grid_size, im_size, ndims, order, alp
         numpoints (tuple): Number of points to use for interpolation in each
             dimension. Default is six points in each direction.
         table_oversamp (tuple): Table oversampling factor.
-        im_size (tuple): Size of base image.
         grid_size (tuple): Size of the grid to interpolate from.
-        n_shift (tuple): Number of points to shift for fftshifts.
+        im_size (tuple): Size of base image.
         ndims (int): Number of image dimensions.
         order (tuple): Order of Kaiser-Bessel kernel.
         alpha (tuple): KB parameter.
@@ -159,8 +158,9 @@ def kaiser_bessel_ft(om, npts, alpha, order, d):
         om (ndarray): An array of coordinates to interpolate to.
         npts (int): Number of points to use for interpolation in each
             dimension.
-        order (ind, default=0): Order of Kaiser-Bessel kernel.
+        order (int): Order of Kaiser-Bessel kernel.
         alpha (double or array of doubles): KB parameter.
+        d (int):  # TODO: find what d is
 
     Returns:
         ndarray: The scaling coefficients.
@@ -182,9 +182,6 @@ def compute_scaling_coefs(im_size, grid_size, numpoints, alpha, order):
         grid_size (tuple): Size of the grid to interpolate from.
         numpoints (tuple): Number of points to use for interpolation in each
             dimension. Default is six points in each direction.
-        table_oversamp (tuple): Table oversampling factor.
-        im_size (tuple): Size of base image.
-        grid_size (tuple): Size of the grid to interpolate from.
         alpha (tuple): KB parameter.
         order (tuple): Order of Kaiser-Bessel kernel.
 


### PR DESCRIPTION
I am atm redoing the docs for my own package and I noticed that some legacy from torchkbnufft were a bit off:
- package install for profiling (in the readme)
- some function docs in utils

I don't know what `d` is in the fourier transform of the kaiser-bessel kernel, so I can let you correct that.