### PR TITLE
Add PyTorch 1.7 FFT compatibility

### DIFF
--- a/torchkbnufft/nufft/fft_compatibility.py
+++ b/torchkbnufft/nufft/fft_compatibility.py
@@ -1,0 +1,39 @@
+import torch
+from torch import Tensor
+from packaging import version
+
+if version.parse(torch.__version__) >= version.parse("1.7.0"):
+    import torch.fft  # type: ignore
+
+
+def fft_old(image: Tensor, ndim: int, normalized: bool = False) -> Tensor:
+    return torch.fft(image, ndim, normalized)
+
+
+def ifft_old(image: Tensor, ndim: int, normalized: bool = False) -> Tensor:
+    return torch.ifft(image, ndim, normalized)
+
+
+def fft_new(image: Tensor, ndim: int, normalized: bool = False) -> Tensor:
+    norm = "ortho" if normalized else None
+    dims = tuple(range(-ndim, 0))
+
+    image = torch.view_as_real(
+        torch.fft.fftn(  # type: ignore
+            torch.view_as_complex(image.contiguous()), dim=dims, norm=norm
+        )
+    )
+
+    return image
+
+
+def ifft_new(image: Tensor, ndim: int, normalized: bool = False) -> Tensor:
+    norm = "ortho" if normalized else None
+    dims = tuple(range(-ndim, 0))
+    image = torch.view_as_real(
+        torch.fft.ifftn(  # type: ignore
+            torch.view_as_complex(image.contiguous()), dim=dims, norm=norm
+        )
+    )
+
+    return image

--- a/torchkbnufft/nufft/toep_functions.py
+++ b/torchkbnufft/nufft/toep_functions.py
@@ -3,8 +3,12 @@ import itertools
 
 import numpy as np
 import torch
+from packaging import version
 
-from ..math import absolute
+if version.parse(torch.__version__) >= version.parse("1.7.0"):
+    from .fft_compatibility import fft_new as fft_fn
+else:
+    from .fft_compatibility import fft_old as fft_fn
 
 
 def calc_toep_kernel(adj_ob, om, weights=None):
@@ -117,9 +121,7 @@ def _get_kern(om, weights, flip_list, base_flip, adj_ob):
     inv_permute_dims = (0, 1, kern.ndim - 1) + tuple(range(2, kern.ndim - 1))
 
     # put the kernel in fft space
-    kern = torch.fft(kern.permute(permute_dims), kern.ndim - 3).permute(
-        inv_permute_dims
-    )
+    kern = fft_fn(kern.permute(permute_dims), kern.ndim - 3).permute(inv_permute_dims)
 
     if adj_ob.norm == "ortho":
         kern = kern / torch.sqrt(torch.prod(torch.tensor(kern.shape[3:], dtype=dtype)))


### PR DESCRIPTION
This PR adds compatibility for the new PyTorch 1.7 complex number FFT. It handles it just by converting the real tensor to complex and back.