### PR TITLE
Patch forward autograd

### DIFF
--- a/torchkbnufft/__init__.py
+++ b/torchkbnufft/__init__.py
@@ -1,6 +1,6 @@
 """Package info"""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __author__ = "Matthew Muckley"
 __author_email__ = "matt.muckley@gmail.com"
 __license__ = "MIT"

--- a/torchkbnufft/_nufft/fft.py
+++ b/torchkbnufft/_nufft/fft.py
@@ -68,8 +68,6 @@ def fft_and_scale(
         pad_sizes.append(0)
         pad_sizes.append(int(gd - im))
 
-    scaling_coef = scaling_coef.unsqueeze(0).unsqueeze(0)
-
     # multiply by scaling_coef, pad, then fft
     return fft_fn(
         F.pad(image * scaling_coef, pad_sizes),
@@ -110,8 +108,6 @@ def ifft_and_scale(
 
     # calculate crops
     dims = torch.arange(len(im_size), device=image.device) + 2
-
-    scaling_coef = scaling_coef.unsqueeze(0).unsqueeze(0)
 
     # ifft, crop, then multiply by scaling_coef conjugate
     return (


### PR DESCRIPTION
Fixes Issue #22. An incredibly weird bug that broke autograd that only occurred when calling `forward` multiple times, and it was caused by using `unsqueeze` operations.