### PR TITLE
Update torchkbnufft to 1.2 for PyTorch 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ the following is a partial list of other projects:
 
 2. Beatty, P. J., Nishimura, D. G., & Pauly, J. M. (2005). [Rapid gridding reconstruction with a minimal oversampling ratio](https://doi.org/10.1109/TMI.2005.848376). *IEEE Transactions on Medical Imaging*, 24(6), 799-808.
 
-3. Feichtinger, H. G., Gr, K., & Strohmer, T. (1995). [Efficient numerical methods in non-uniform sampling theory](https://doi.org/10.1007/s002110050101). Numerische Mathematik, 69(4), 423-440.
+3. Feichtinger, H. G., Gr, K., & Strohmer, T. (1995). [Efficient numerical methods in non-uniform sampling theory](https://doi.org/10.1007/s002110050101). *Numerische Mathematik*, 69(4), 423-440.
 
 ## Citation
 
@@ -226,7 +226,7 @@ If you use the package, please cite:
 ```bibtex
 @conference{muckley:20:tah,
   author = {M. J. Muckley and R. Stern and T. Murrell and F. Knoll},
-  title = {{TorchKbNufft}: A High-Level, Hardware-Agnostic Non-Uniform Fast Fourier Transform},
+  title = {{TorchKbNufft}: A High-Level, Hardware-Agnostic Non-Uniform Fast {Fourier} Transform},
   booktitle = {ISMRM Workshop on Data Sampling \& Image Reconstruction},
   year = 2020
 }

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 black==20.8b1
-pytest==6.1.1
-flake8==3.8.4
-mypy==0.790
-pillow==8.1.1
+pytest==6.2.3
+flake8==3.9.0
+mypy==0.812
+pillow==8.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-torch==1.8
+torch==1.8.1
 numpy==1.19.2
 scipy==1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-torch==1.7.1
+torch==1.8
 numpy==1.19.2
 scipy==1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 torch==1.8.1
-numpy==1.19.2
-scipy==1.5.2
+numpy==1.20.2
+scipy==1.6.2

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ builtins.__TORCHKBNUFFT_SETUP__ = True
 
 import torchkbnufft  # noqa: E402
 
-install_requires = ["torch>=1.7", "numpy", "scipy"]
+install_requires = ["torch>=1.8", "numpy", "scipy"]
 
 # https://packaging.python.org/discussions/install-requires-vs-requirements
 setup(

--- a/torchkbnufft/__init__.py
+++ b/torchkbnufft/__init__.py
@@ -1,6 +1,6 @@
 """Package info"""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 __author__ = "Matthew Muckley"
 __author_email__ = "matt.muckley@gmail.com"
 __license__ = "MIT"

--- a/torchkbnufft/_nufft/interp.py
+++ b/torchkbnufft/_nufft/interp.py
@@ -616,7 +616,6 @@ def table_interp_adjoint(
     dtype = data.dtype
     device = data.device
     int_type = torch.long
-    # cpu_device = device == torch.device("cpu")
     batched_nufft = False
 
     if omega.ndim not in (2, 3):
@@ -688,9 +687,7 @@ def table_interp_adjoint(
 
     # loop over offsets
     for offset in offsets:
-        # TODO: Figure out if we are still doing thread management properly here
-        # if USING_OMP and cpu_device and batched_nufft:
-        #     torch.set_num_threads(threads_per_fork)
+        # TODO: see if we can fix thread counts in forking
         coef, arr_ind = calc_coef_and_indices_fork_over_batches(
             tm,
             base_offset,
@@ -703,16 +700,11 @@ def table_interp_adjoint(
             num_forks,
             batched_nufft,
         )
-        # if USING_OMP and cpu_device and batched_nufft:
-        #     torch.set_num_threads(num_threads)
 
         # multiply coefs to data
         if coef.ndim == 2:
             coef = coef.unsqueeze(1)
             assert coef.ndim == data.ndim
-
-        # if USING_OMP and cpu_device:
-        #     torch.set_num_threads(threads_per_fork)
 
         # this is a much faster way of doing index accumulation
         if batched_nufft:
@@ -730,8 +722,5 @@ def table_interp_adjoint(
                 num_forks,
                 batched_nufft,
             ).view(data.shape[0], data.shape[1], output_prod)
-
-        # if USING_OMP and cpu_device:
-        #     torch.set_num_threads(num_threads)
 
     return image.view(output_size)

--- a/torchkbnufft/_nufft/interp.py
+++ b/torchkbnufft/_nufft/interp.py
@@ -277,7 +277,6 @@ def table_interp_fork_over_kspace(
     num_forks: int,
 ) -> Tensor:
     """Table interpolation backend (see table_interp())."""
-
     # indexing is worst when we have repeated indices - let's spread them out
     klength = omega.shape[1]
     omega_chunks = [omega[:, ind:klength:num_forks] for ind in range(num_forks)]

--- a/torchkbnufft/_nufft/utils.py
+++ b/torchkbnufft/_nufft/utils.py
@@ -92,7 +92,7 @@ def build_numpy_spmatrix(
     kk = kd[0]
     spmat_coef = full_coef[0]
     for i in range(1, ndims):
-        Jprod = np.prod(numpoints[: i + 1])
+        Jprod = int(np.prod(numpoints[: i + 1]))
         # block outer sum
         kk = np.reshape(
             np.expand_dims(kk, 1) + np.expand_dims(kd[i], 2), (klength, Jprod)
@@ -109,7 +109,7 @@ def build_numpy_spmatrix(
 
     # get coordinates in sparse matrix
     trajind = np.expand_dims(np.arange(klength), 1)
-    trajind = np.repeat(trajind, np.prod(numpoints), axis=1)
+    trajind = np.repeat(trajind, int(np.prod(numpoints)), axis=1)
 
     # build the sparse matrix
     spmat = coo_matrix(


### PR DESCRIPTION
This update utilizes new PyTorch 1.8 features, most importantly native complex operations for the `index_add_` function in the adjoint on the GPU. It also removes some thread management code that led to a performance regression on PyTorch 1.8 (Issue #25). A further list of changes is below:

- Update `requirements.txt` and `dev-requirements.txt` to latest packages.
- Remove `calc_split_sizes` - we can now use `tensor_split`.
- Removed some calls to tensor attributes - these can be expensive.
- Removal of `kwarg` usage for some `torch.jit.script` functions - these can behave strangely with scripted functions.
- Removal of `index_put` for accumulation. We now only use `index_add`.