### PR TITLE
correct shape of weights

### DIFF
--- a/torchkbnufft/_nufft/toep.py
+++ b/torchkbnufft/_nufft/toep.py
@@ -154,6 +154,7 @@ def calc_one_batch_toeplitz_kernel(
         weights = weights.unsqueeze(0).unsqueeze(0)
     else:
         weights = weights.to(adj_ob.table_0)
+        weights = weights.unsqueeze(0)
 
     # apply adjoints to n-1 dimensions
     if omega.shape[0] > 1:


### PR DESCRIPTION
I tried to provide weights to `calc_toeplitz_kernel` running this script:

```
import torch
import torchkbnufft as tkbn

image = torch.randn(1,1,8,8) + 1j * torch.randn(1,1,8,8)
omega = torch.rand(2,12)
weights = torch.ones(1,12)
toep_ob = tkbn.ToepNufft()
kernel = tkbn.calc_toeplitz_kernel(omega, im_size=[8,8], weights=weights)
image = toep_ob(image, kernel)
```

but it failed, because the dimensions of weights are not correctly adapted in `calc_one_batch_toeplitz_kernel`. This pull request should fix this.