### PR TITLE
single smaps for batches

### DIFF
--- a/torchkbnufft/modules/kbnufft.py
+++ b/torchkbnufft/modules/kbnufft.py
@@ -444,17 +444,30 @@ class ToepNufft(torch.nn.Module):
         output = []
         if len(kernel.shape) > len(image.shape[2:]):
             # run with batching for kernel
-            for (mini_image, smap, mini_kernel) in zip(image, smaps, kernel):
-                mini_image = mini_image.unsqueeze(0) * smap.unsqueeze(0)
-                mini_image = tkbnF.fft_filter(
-                    image=mini_image, kernel=mini_kernel, norm=norm
-                )
-                mini_image = torch.sum(
-                    mini_image * smap.unsqueeze(0).conj(),
-                    dim=1,
-                    keepdim=True,
-                )
-                output.append(mini_image.squeeze(0))
+            if smaps.shape[0] == 1:  
+                for (mini_image, mini_kernel) in zip(image, kernel):
+                    mini_image = mini_image.unsqueeze(0) * smaps
+                    mini_image = tkbnF.fft_filter(
+                        image=mini_image, kernel=mini_kernel, norm=norm
+                    )
+                    mini_image = torch.sum(
+                        mini_image * smaps.conj(),
+                        dim=1,
+                        keepdim=True,
+                    )
+                    output.append(mini_image.squeeze(0))
+            else:
+                for (mini_image, smap, mini_kernel) in zip(image, smaps, kernel):
+                    mini_image = mini_image.unsqueeze(0) * smap.unsqueeze(0)
+                    mini_image = tkbnF.fft_filter(
+                        image=mini_image, kernel=mini_kernel, norm=norm
+                    )
+                    mini_image = torch.sum(
+                        mini_image * smap.unsqueeze(0).conj(),
+                        dim=1,
+                        keepdim=True,
+                    )
+                    output.append(mini_image.squeeze(0))
         else:
             for (mini_image, smap) in zip(image, smaps):
                 mini_image = mini_image.unsqueeze(0) * smap.unsqueeze(0)

--- a/torchkbnufft/modules/kbnufft.py
+++ b/torchkbnufft/modules/kbnufft.py
@@ -444,7 +444,7 @@ class ToepNufft(torch.nn.Module):
         output = []
         if len(kernel.shape) > len(image.shape[2:]):
             # run with batching for kernel
-            if smaps.shape[0] == 1:  
+            if smaps.shape[0] == 1:
                 for (mini_image, mini_kernel) in zip(image, kernel):
                     mini_image = mini_image.unsqueeze(0) * smaps
                     mini_image = tkbnF.fft_filter(


### PR DESCRIPTION
Running this code

```
import torch
import torchkbnufft as tkbn

image = torch.randn(11,1,8,8) + 1j * torch.randn(11,1,8,8)
smaps = torch.randn(11,1,8,8) + 1j * torch.randn(11,1,8,8)
omega = torch.rand(11,2,12)

toep_ob = tkbn.ToepNufft()
kernel = tkbn.calc_toeplitz_kernel(omega, im_size=[8,8])
image = toep_ob(image, kernel, smaps=smaps)
```
will carry out the Forward/backward NUFFT with Toeplitz embedding for all 11 batches. Nevertheless, often batches correspond to different dynamics and for those `smaps` is always the same (as it depends on the hardware rather than the underlying object to be imaged). In order to avoid having to make nbatch copies of smaps this PR allows for the following:

```
image = torch.randn(11,1,8,8) + 1j * torch.randn(11,1,8,8)
smaps = torch.randn(1,1,8,8) + 1j * torch.randn(1,1,8,8)
omega = torch.rand(11,2,12)

toep_ob = tkbn.ToepNufft()
kernel = tkbn.calc_toeplitz_kernel(omega, im_size=[8,8])
image = toep_ob(image, kernel, smaps=smaps)
```

Remark: The above code with smaps.shape = [1,1,8,8] will also run with the current main-branch but it will yield an image of dimension [1,1,8,8] rather than [11,1,8,8].