### PR TITLE
Remove pillow dependency

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,4 +3,3 @@ black==22.3.0
 pytest==7.1.2
 flake8==4.0.1
 mypy==0.961
-pillow==9.3.0

--- a/profile_torchkbnufft.py
+++ b/profile_torchkbnufft.py
@@ -2,6 +2,9 @@ import time
 
 import numpy as np
 import torch
+
+# NOTE: pillow and scikit-image are not project dependencies and need to be
+# installed sepearately to run this script
 from PIL import Image
 from skimage.data import camera
 


### PR DESCRIPTION
Pillow is only used in `profile_torchkbnufft.py`, which is not really part of the main package and isn't used for continuous integration. So we'll just put a note there to install pillow and remove it to get rid of dependency bot issues (e.g., PR #75).