### PR TITLE
Test updated torch dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-torch==1.10.0
+torch==1.12.1
 numpy==1.22.4
 scipy==1.8.1

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ builtins.__TORCHKBNUFFT_SETUP__ = True
 
 import torchkbnufft  # noqa: E402
 
-install_requires = ["torch>=1.10,<1.11", "numpy", "scipy"]
+install_requires = ["torch>=1.12", "numpy", "scipy"]
 
 # https://packaging.python.org/discussions/install-requires-vs-requirements
 setup(

--- a/torchkbnufft/_nufft/utils.py
+++ b/torchkbnufft/_nufft/utils.py
@@ -10,7 +10,6 @@ from torch import Tensor
 DTYPE_MAP = [
     (torch.complex128, torch.float64),
     (torch.complex64, torch.float32),
-    (torch.complex32, torch.float16),
 ]
 
 


### PR DESCRIPTION
`torch.complex64` and `torch.complex128` were previously removed, but are now back as of PyTorch 1.12. So we can update our dependencies now that we have access to these again.