### PR TITLE
Fixes for release action

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,6 +21,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
+    - name: Build package
+      run: |
+        python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,11 +5,10 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +22,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
v1.4.0 didn't correctly trigger the release. This PR converts it to use a different action, as well as changing the trigger to "published".