### PR TITLE
conftest.py: allow running tests with numpy 2.0

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def test_params():
 
 
 def create_input_plus_noise(shape, is_complex):
-    x = np.arange(np.product(shape)).reshape(shape)
+    x = np.arange(np.prod(shape)).reshape(shape)
     x = torch.tensor(x, dtype=torch.get_default_dtype())
 
     if is_complex:


### PR DESCRIPTION
Hi,

I thought I'd make the package available on conda-forge so that it can be used itself as a dependency for building other conda packages. See here for the corresponding PR https://github.com/conda-forge/staged-recipes/pull/28200

During building the conda package, I emphasized installability of the package in the conda-forge ecosystem for the tests after the conda package is built, which means I deliberately did not pin the test requirements, which then defaults to installing with numpy 2.x. This revealed the test incompatibility with numpy 2.0 that this PR addresses so that tests can pass with numpy 2.x. It was a simple deprecation of the `np.product` alias for `np.prod`, see https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#main-namespace.

An open issue is that by default, the install also with pytorch 2.x, which currently breaks the Toeplitz notebook, but there's already a corresponding issue here #98 

Please let me know if you would like to be added as a recipe maintainer for conda-forge, @mmuckley 
